### PR TITLE
added cefr labelling

### DIFF
--- a/py_lift/annotators.py
+++ b/py_lift/annotators.py
@@ -3,7 +3,9 @@ from cassis import Cas
 from util import load_typesystem
 from spellchecker import SpellChecker
 from cassis.typesystem import TYPE_NAME_FS_ARRAY
-from dkpro import T_TOKEN, T_ANOMALY, T_SUGGESTION, T_LEMMA
+from dkpro import T_TOKEN, T_ANOMALY, T_SUGGESTION, T_LEMMA, T_POS
+
+import pandas as pd
 
 class SE_SpellErrorAnnotator():
 
@@ -64,4 +66,103 @@ class SE_EasyWordAnnotator():
                 print("Found easy word: ", t_str)
             else:
                 print("Found not so easy word: ", t_str)
+        return True
+
+
+class SE_CEFRAnnotator():
+
+    def __init__(self, language):
+        self.language = language
+        supported_langs = ['en']
+        if self.language not in supported_langs:
+            raise ValueError(
+                f"{self.language} is not a supported language."
+            )
+        from pathlib import Path
+
+        file_path = Path(
+            __file__).parent.parent / "shared_resources" / "resources" / "evp" / "EVP.csv"
+
+        df = pd.read_csv(file_path)
+        df.columns = ['word', 'pos', 'level']
+        df = df.drop_duplicates(subset=['word', 'pos'], keep='first')
+
+        self.pos_tag_map = {
+
+            'CC': 'none',
+            'CD': 'none',
+            'DT': 'determiner',
+            'EX': 'adverb',
+            'FW': 'none',
+            'IN': 'preposition',
+            'JJ': 'adjective',
+            'JJR': 'adjective',
+            'JJS': 'adjective',
+            'LS': 'none',
+            'MD': 'verb',
+            'NN': 'noun',
+            'NNS': 'noun',
+            'NNP': 'noun',
+            'NNPS': 'noun',
+            'PDT': 'determiner',
+            'POS': 'none',
+            'PRP': 'pronoun',
+            'PRP$': 'pronoun',
+            'RB': 'adverb',
+            'RBR': 'adverb',
+            'RBS': 'adverb',
+            'RP': 'none',
+            'SYM': 'none',
+            'TO': 'none',
+            'UH': 'none',
+            'VB': 'verb',
+        'VBD': "verb", "VBG": "verb", "VBN": "verb", "VBP":"verb", "VBZ": "verb", "WDT": "determiner", "WP": "pronoun", "WP$": "determiner", "WRB": "adverb"
+        }
+
+        # TODO: Move pos info to keys of dictionary?
+        #self.cefr_words = {(word, pos): level for word, pos, level in zip(df['word'], df['pos'], df['level'])}
+
+        cefr_words = {}
+        for word, pos, level in zip(df['word'], df['pos'], df['level']):
+
+            word_dict = cefr_words.get(word, {})
+            word_dict[pos] = level
+            cefr_words[word] = word_dict
+
+        self.cefr_words = cefr_words
+        self.ts = load_typesystem('data/TypeSystem.xml')
+        self.cefr = self.ts.get_type("org.lift.type.CEFR")
+
+    def process(self, cas: Cas) -> bool:
+        for lemma in cas.select(T_LEMMA):
+            t_str = lemma.value
+
+            if t_str in self.cefr_words.keys():
+
+                if len(self.cefr_words[t_str]) > 1:
+
+                    word_dict = self.cefr_words[t_str]
+
+                    t_pos = cas.select_covered(type_=T_POS, covering_annotation=lemma)[0]
+                    pos_value = t_pos.PosValue
+                    our_pos_value = self.pos_tag_map[pos_value]
+
+                    if our_pos_value in word_dict.keys():
+                        cefr_word = self.cefr(begin=lemma.begin, end=lemma.end, level=word_dict[our_pos_value], pos=our_pos_value)
+                        cas.add(cefr_word)
+
+                    else:
+
+                        # Take pos with lowest level
+                        cefr_word = self.cefr(begin=lemma.begin, end=lemma.end, level=min(word_dict.values()), pos=min(word_dict, key=word_dict.get))
+                        cas.add(cefr_word)
+
+                else:
+
+                    cefr_word = self.cefr(begin=lemma.begin, end=lemma.end, level=list(self.cefr_words[t_str].values())[0], pos=list(self.cefr_words[t_str].keys())[0])
+                    cas.add(cefr_word)
+
+                print("Found cefr word: ", t_str)
+            else:
+                print("Found not so cefr word: ", t_str)
         return True

--- a/py_lift/data/TypeSystem.xml
+++ b/py_lift/data/TypeSystem.xml
@@ -1413,6 +1413,26 @@ d) redundant/wrongly added negation word (G_Neg_neggen_Ad-->
               <name>org.lift.type.EasyWord</name>
               <supertypeName>uima.tcas.Annotation</supertypeName>
             </typeDescription>
+
+            <typeDescription>
+              <name>org.lift.type.CEFR</name>
+              <supertypeName>uima.tcas.Annotation</supertypeName>
+
+                <features>
+
+                <featureDescription>
+                    <name>level</name>
+                    <description/>
+                    <rangeTypeName>uima.cas.Integer</rangeTypeName>
+                </featureDescription>
+
+                <featureDescription>
+                    <name>pos</name>
+                    <description/>
+                    <rangeTypeName>uima.cas.String</rangeTypeName>
+                </featureDescription>
+            </features>
+            </typeDescription>
                       
             
             

--- a/py_lift/tests/test_annotator_cefr.py
+++ b/py_lift/tests/test_annotator_cefr.py
@@ -1,0 +1,84 @@
+import pytest
+from util import load_typesystem
+from cassis import Cas
+from extractors import FE_TokensPerSentence, FE_EasyWordRatio
+from annotators import SE_EasyWordAnnotator, SE_CEFRAnnotator
+
+T_TOKEN = 'de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token'
+T_SENTENCE = 'de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence'
+T_FEATURE = 'org.lift.type.CEFR'
+T_EASYWORD = 'org.lift.type.EasyWord'
+T_LEMMA = 'de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Lemma'
+T_POS = "de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.pos.POS"
+
+def test_cefr_extractor():
+    ts = load_typesystem('data/TypeSystem.xml')
+    cas = Cas(typesystem=ts)
+    cas.sofa_string = "This is a test. A minimal metaphor. Fake. Fake."
+
+    # TODO can we take more convenient way to test CASes from Cassis?
+    T = ts.get_type(T_TOKEN)
+    t1 = T(begin=0, end=4)
+    t2 = T(begin=5, end=7)
+    t3 = T(begin=8, end=9)
+    t4 = T(begin=10, end=14)
+    t5 = T(begin=14, end=15)
+    t6 = T(begin=16, end=17)
+    t7 = T(begin=18, end=22)
+    t8 = T(begin=23, end=30)
+    t9 = T(begin=31, end=32)
+    t10 = T(begin=33, end=37)
+    t11 = T(begin=38, end=39)
+    t12 = T(begin=40, end=44)
+    t13 = T(begin=45, end=46)
+    cas.add_all([t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13])
+
+    L = ts.get_type(T_LEMMA)
+    l1 = L(begin=0, end=4, value="this")
+    l2 = L(begin=5, end=7, value="be")
+    l3 = L(begin=8, end=9, value="a")
+    l4 = L(begin=10, end=14, value="test")
+    l5 = L(begin=14, end=15, value=".")
+    l6 = L(begin=16, end=17, value="a")
+    l7 = L(begin=18, end=22, value="minimal")
+    l8 = L(begin=23, end=30, value="metaphor")
+    l9 = L(begin=31, end=32, value=".")
+    l10 = L(begin=33, end=37, value="Fake")
+    l11 = L(begin=38, end=39, value=".")
+    l12 = L(begin=40, end=44, value="Fake")
+    l13 = L(begin=45, end=46, value=".")
+    cas.add_all([l1, l2, l3, l4, l5, l6, l7, l8, l9, l10, l11, l12, l13])
+
+    POS = ts.get_type(T_POS)
+    pos1 = POS(begin=0, end=4, PosValue="NN")
+    pos2 = POS(begin=5, end=7, PosValue="VB")
+    pos3 = POS(begin=8, end=9, PosValue="DT")
+    pos4 = POS(begin=10, end=14, PosValue="NN")
+    pos5 = POS(begin=14, end=15, PosValue=".")
+    pos6 = POS(begin=16, end=17, PosValue="DT")
+    pos7 = POS(begin=18, end=22, PosValue="JJ")
+    pos8 = POS(begin=23, end=30, PosValue="NN")
+    pos9 = POS(begin=31, end=32, PosValue=".")
+    pos10 = POS(begin=33, end=37, PosValue="JJ")
+    pos11 = POS(begin=38, end=39, PosValue=".")
+    pos12 = POS(begin=40, end=44, PosValue="NN")
+    pos13 = POS(begin=45, end=46, PosValue=".")
+    cas.add_all([pos1, pos2, pos3, pos4, pos5, pos6, pos7, pos8, pos9, pos10, pos11, pos12, pos13])
+
+    SE_CEFRAnnotator("en").process(cas)
+
+    words = ["This", "is", "a", "test", "A", "minimal", "metaphor", "Fake", "Fake"]
+    labels_cefr = [1, 1, 1, 1, 1, 5, 6, 5, 6]
+
+    words_with_level = {word: level for word, level in zip(words, labels_cefr)}
+
+    for feature in cas.select(T_FEATURE):
+        if feature.get_covered_text() in words:
+            assert feature.level == words_with_level[feature.get_covered_text()]
+        else:
+            print('Test failed :)')
+
+
+
+
+    


### PR DESCRIPTION
We added code to label each token in a text with its corresponding cefr-level that we gained from the evp file in the repository. We also created a unit test to make sure that edge cases (multiple occurences of a word within the evp file with differing cefr levels as well as mismatches in pos-tags in evp and Penn Treebank) are taken care of. 